### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,5 +1,8 @@
 name: Build solution
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/panuoksala/streamdeck-fabric-plugin/security/code-scanning/1](https://github.com/panuoksala/streamdeck-fabric-plugin/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since the workflow only performs basic CI tasks (checking out code, restoring dependencies, and building a solution), it only needs `contents: read` permissions. This change ensures that the workflow cannot perform unintended write operations or access other sensitive resources.

The `permissions` block should be added at the top level of the workflow file, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
